### PR TITLE
fix: rename GITHUB_TOKEN to GH_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,5 +19,5 @@ jobs:
       - name: semantic release
         uses: cycjimmy/semantic-release-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,6 @@ name: Release NPM package
 on:
   push:
     branches: [ 'main' ]
-  pull_request:
-    branches: [ 'main' ]
 
 jobs:
   release:


### PR DESCRIPTION
- GITHUB_ is reserved on github, hence the new name GH_TOKEN