### PR TITLE
fix: remove clutter from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "main": "./lib/esm/index.js",
   "types": "./lib/esm/types/index.d.ts",
   "files": [
-    "./lib",
+    "./lib/**/*",
     "!**/*.stories.js",
     "!**/*.stories.d.ts",
     "!**/reportWebVitals.js",


### PR DESCRIPTION
- remove stories, webVitals and testSetup from tarball