### PR TITLE
fix(modal-backgrop-bgcolor): add opacity for backgrop bg-color of modal

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -47,7 +47,7 @@ export const Modal: FC<ModalProps> = ({
                 >
                     <div
                         role="backgrop"
-                        className="fixed inset-0 bg-primary-600"
+                        className="fixed inset-0 bg-primary-600/40"
                         aria-hidden="true"
                     />
                 </Transition.Child>

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -46,7 +46,7 @@ export const Modal: FC<ModalProps> = ({
                     leaveTo="opacity-0"
                 >
                     <div
-                        role="backgrop"
+                        role="backdrop"
                         className="fixed inset-0 bg-primary-600/40"
                         aria-hidden="true"
                     />


### PR DESCRIPTION
- add the opacity in the class for the backgrop bg-color

See also in Headless UI doc: https://headlessui.com/react/dialog#adding-a-backdrop