### PR TITLE
fix(release-npm-publish): add new copyright year and make npm publish

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright &copy; 2023 CAS Frontend Engineering Advanced 2023 / 2024
+Copyright &copy; 2024 CAS Frontend Engineering Advanced 2023 / 2024
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- merge request with the chore prefix name will not make a new npm publish release
- therefore we need to make npm publish with the new release (fix or feat)
- change the copyright in the licence fle

This MR is connected with merged MR (originally):
https://github.com/ost-cas-fee-adv-23-24/design-system-component-library-pixelpioneers/pull/98